### PR TITLE
Deposit WETH

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,3 +21,8 @@ def lido(interface, accounts):
     lido = interface.Lido("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84")
     oracle = accounts.at(lido.getOracle(), force=True)
     return interface.Lido(lido, owner=oracle)
+
+
+@pytest.fixture
+def weth(interface, ape):
+    return interface.ERC20("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", owner=ape)

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -30,3 +30,15 @@ def test_ape_in(vault, lido, ape):
     vault.withdraw()
     assert lido.balanceOf(ape) > 0
     assert vault.balanceOf(ape) == 0
+
+
+def test_weth_in(vault, lido, weth, ape):
+    ape.transfer(weth, "1 ether")
+    weth.approve(vault, "1 ether")
+    vault.depositWeth("1 ether")
+    assert lido.balanceOf(ape) == 0
+    assert vault.balanceOf(ape) > 0
+    lido.pushBeacon(0, "100 ether")
+    vault.withdraw()
+    assert lido.balanceOf(ape) > 0
+    assert vault.balanceOf(ape) == 0


### PR DESCRIPTION
Likely not merging this as it adds unnecessary complexity and doesn't improve on the user experience.

A user might as well call
1. `Weth.withdraw()`
2. `Vault.__default__()`

Instead of:
1. `Weth.approve()`
2. `Vault.depositWeth()`

While depositing with ether is just one single transaction.